### PR TITLE
Prevent using branch names or shortened commit hashes for github blob source URLs.

### DIFF
--- a/.github/workflows/json-linter.yml
+++ b/.github/workflows/json-linter.yml
@@ -24,3 +24,12 @@ jobs:
           FILTER_REGEX_INCLUDE: .*data/.*
           DEFAULT_BRANCH: "main"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint Source URLs
+        run: >-
+          for url in $(jq .items[].source_url < data/entries.json); do
+            echo $url | grep -q blob && (echo $url | sed -nr \
+              's,^"https://github.com/[^\/]*/[^\/]*/blob/([^/]*)/.+$,\1,p' |
+              grep -q '[0-9a-f]\{40\}' || (echo \
+              "Error: $url does not contain a commit hash." && exit 1));
+          done

--- a/data/entries.json
+++ b/data/entries.json
@@ -66,7 +66,7 @@
                 "COPA"
             ],
             "source": "Repo",
-            "source_url": "https://github.com/Tencent/tquic/blob/develop/README.md?plain=1#L19",
+            "source_url": "https://github.com/Tencent/tquic/blob/04e656cb68100caad9cdd1ad1e31b10be6799b07/README.md?plain=1#L19",
             "created_at": "2024-01-30T10:45:00.000000Z",
             "created_by": "Benedikt Spies <benedikt.spies@in.tum.de>"
         },


### PR DESCRIPTION
This should prevent accidentally linking to a changing url.